### PR TITLE
Fix Slider Alignment and Scrollbar Appearance

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -6,6 +6,8 @@
 
 body{
   background-color: #051644;
+  /* fixes scrollbar showing when the events rotate */
+  overflow: hidden;
 }
 
 /*Contains the rest of the content*/

--- a/css/style.css
+++ b/css/style.css
@@ -81,8 +81,6 @@ img.announcement{
   display: block;
   max-width: 100%;
   max-height: 100%;
-  margin-left: auto;
-  margin-right: auto;
 }
 
 /*


### PR DESCRIPTION
Sliders are left-aligned when they appear to remove jarring "pop" when they slide in.
body overflow is set to hidden to fix the browser scrollbar appearing in fullscreen mode every time the events rotated. 