### PR TITLE
Clarified where head image is, in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ swap_frequency = 4000
 slide_frequency = 3000
 ; every 2 hours to refresh the page (in milliseconds)
 page_refresh_frequency = 7.2e+6
-; path to the header image
+; path to the header image, relative to the root of the app
 slide_head_img = "images/headlogo.png"
 ; full path to the folder where the slider images are
 slide_img_path = "C:\some\path\to\slide\images"


### PR DESCRIPTION
I thought that the `slide_head_img` setting was broken, but I just had the wrong image file in my .conf. 
This adds a little clarification in the readme that the image path is relative to the root of the app.